### PR TITLE
Added CKEditor compatibility

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -8,9 +8,9 @@ end
 Redmine::Plugin.register :redmine_mentions do
   name 'Redmine Mentions'
   author 'Arkhitech'
-  description 'This is a plugin for Redmine which gives suggestions on using username in comments'
-  version '0.0.1'
-  url 'https://github.com/arkhitech/redmine_mentions'
+  description 'This is a plugin for Redmine which gives suggestions on using username in comments. This version adds a workaround to avoid CKEditor incompatibility, without supporting mentions in CKEditor.'
+  version '0.0.2'
+  url 'https://github.com/scrapinghub/redmine_mentions'
   author_url 'http://www.arkhitech.com/'
   settings :default => {'trigger' => '@'}, :partial => 'settings/mention'
 end

--- a/lib/redmine_mentions/hooks.rb
+++ b/lib/redmine_mentions/hooks.rb
@@ -1,15 +1,29 @@
 module RedmineMentions
-  class Hooks < Redmine::Hook::ViewListener
-    # This just renders the partial in
-    # app/views/hooks/my_plugin/_view_issues_form_details_bottom.rhtml
-    # The contents of the context hash is made available as local variables to the partial.
-    #
-    # Additional context fields
-    #   :issue  => the issue this is edited
-    #   :f      => the form object to create additional fields
-    render_on :view_issues_edit_notes_bottom,
-              :partial => 'hooks/redmine_mentions/edit_mentionable'
-    render_on :view_issues_form_details_bottom,
-              :partial => 'hooks/redmine_mentions/edit_mentionable'
-  end
+	class Hooks < Redmine::Hook::ViewListener
+		# This just renders the partial in
+		# app/views/hooks/my_plugin/_view_issues_form_details_bottom.rhtml
+		# The contents of the context hash is made available as local variables to the partial.
+		#
+		# Additional context fields
+		#   :issue  => the issue this is edited
+		#   :f      => the form object to create additional fields
+
+		def view_issues_edit_notes_bottom(context={ })
+			if ['textile', 'markdown'].include?(Setting.text_formatting)
+				context[:controller].send(:render_to_string, {
+					:partial => "hooks/redmine_mentions/edit_mentionable",
+					:locals => context
+				})
+			end
+		end
+
+		def view_issues_form_details_bottom(context={ })
+			if ['textile', 'markdown'].include?(Setting.text_formatting)
+				context[:controller].send(:render_to_string, {
+					:partial => "hooks/redmine_mentions/edit_mentionable",
+					:locals => context
+				})
+			end
+		end
+	end
 end


### PR DESCRIPTION
This workaround will allow the contemporary usage of `redmine_mentions` with `textile` and `markdown` without breaking `CKEditor`.
